### PR TITLE
SSH_PKIF usage sync with gravity-sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,4 +80,4 @@ HEALTHCHECK     --interval=5m --timeout=60s --start-period=10s \
                 CMD /usr/local/bin/missionreport.sh
 
 ENTRYPOINT      ["/tini", "--"]
-CMD             ["/usr/local/bin/startup.sh"]
+CMD             ["cat /test && /usr/local/bin/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV             GS_INSTALL="secondary" \
                 DATE_OUTPUT="" \
                 PING_AVOID="" \
                 ROOT_CHECK_AVOID="" \
-                SSH_PKIF=".ssh/id_rsa"
+                SSH_PKIF=""
 
 COPY            ./container_scripts/install_tini.sh /usr/local/bin/install_tini.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,4 +80,4 @@ HEALTHCHECK     --interval=5m --timeout=60s --start-period=10s \
                 CMD /usr/local/bin/missionreport.sh
 
 ENTRYPOINT      ["/tini", "--"]
-CMD             ["cat /test && /usr/local/bin/startup.sh"]
+CMD             ["/usr/local/bin/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV             GS_INSTALL="secondary" \
                 DATE_OUTPUT="" \
                 PING_AVOID="" \
                 ROOT_CHECK_AVOID="" \
-                SSH_PKIF=""
+                SSH_PKIF=".ssh/id_rsa"
 
 COPY            ./container_scripts/install_tini.sh /usr/local/bin/install_tini.sh
 

--- a/container_scripts/configure.sh
+++ b/container_scripts/configure.sh
@@ -37,8 +37,6 @@ connectSsh()
 
 checkSshKeys()
 {
-    echo $HOME > /test
-    echo "$HOME/$SSH_PKIF" >> /test
     if [ -z $HOME/$SSH_PKIF ];
     then
         KEY_PATH="/root/.ssh/id_rsa"

--- a/container_scripts/configure.sh
+++ b/container_scripts/configure.sh
@@ -37,6 +37,8 @@ connectSsh()
 
 checkSshKeys()
 {
+    echo $HOME > /test
+    echo "$HOME/$SSH_PKIF" >> /test
     if [ -z $HOME/$SSH_PKIF ];
     then
         KEY_PATH="/root/.ssh/id_rsa"

--- a/container_scripts/configure.sh
+++ b/container_scripts/configure.sh
@@ -37,11 +37,11 @@ connectSsh()
 
 checkSshKeys()
 {
-    if [ -z $SSH_PKIF ];
+    if [ -z $HOME/$SSH_PKIF ];
     then
         KEY_PATH="/root/.ssh/id_rsa"
     else
-        KEY_PATH=$SSH_PKIF
+        KEY_PATH=$HOME/$SSH_PKIF
     fi
 
     if [ ! -f "${KEY_PATH}" ];

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -37,11 +37,11 @@ docker exec ssh apk add sqlite rsync docker
 #For some reason, gravitysynctest wants to restart now so we will have to wait for it
 wait=30
 echo "Waiting for gravitysynctest to restart"
-until [ docker container ls --format "table {{.Names}}\t{{.Status}}" | grep gravitysynctest | grep Up ]
+until docker container ls --format "table {{.Names}}\t{{.Status}}" | grep gravitysynctest | grep Up
 do
   sleep 1
-  wait=$[$wait-1]
-  if [ $wait -eq 0 ]
+  wait=$($wait-1)
+  if [ "${wait}" -eq 0 ]
   then
     echo "Timed out while awaiting gravitysynctest restart"
     exit 1

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -27,7 +27,9 @@ mkdir -p ${TESTDIR}/.ssh/
 docker run -v "$TESTDIR/:$TESTDIR/.ssh:rw" --rm alpine:latest apk --update add openssh-client && ssh-keygen -q -t rsa -f ${TESTDIR}/.ssh/id_rsa -N ''
 
 # Bring the testing environment online
+echo "Executing Docker Compose Up"
 docker-compose -f ${WORKDIR}/docker-testenvironment-compose.yml up -d
+echo "Docker Compose IS NOW Up"
 
 # Prepare the SSH container to accommodate for GravitySync's requirements
 docker exec ssh sh -c 'chmod +w /etc/sudoers && sudo sed -i "s/^gravitysync.*$/gravitysync ALL=(ALL) NOPASSWD: ALL/" /etc/sudoers'

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -40,7 +40,7 @@ echo "Waiting for gravitysynctest to restart"
 until docker container ls --format "table {{.Names}}\t{{.Status}}" | grep gravitysynctest | grep Up
 do
   sleep 1
-  wait=$wait-1
+  wait="$(($wait - 1))"
   if [ "${wait}" -eq 0 ]
   then
     echo "Timed out while awaiting gravitysynctest restart"

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -28,7 +28,6 @@ docker run -v "$TESTDIR/:$TESTDIR/.ssh:rw" --rm alpine:latest apk --update add o
 
 # Bring the testing environment online
 docker-compose -f ${WORKDIR}/docker-testenvironment-compose.yml up -d
-docker container ls -a --format "table {{.ID}}\t{{.Image}}\t{{.Names}}"
 
 # Prepare the SSH container to accommodate for GravitySync's requirements
 docker exec ssh sh -c 'chmod +w /etc/sudoers && sudo sed -i "s/^gravitysync.*$/gravitysync ALL=(ALL) NOPASSWD: ALL/" /etc/sudoers'

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -34,6 +34,20 @@ echo "Prepare the SSH container to accommodate for GravitySync's requirements"
 docker exec ssh sh -c 'chmod +w /etc/sudoers && sudo sed -i "s/^gravitysync.*$/gravitysync ALL=(ALL) NOPASSWD: ALL/" /etc/sudoers'
 docker exec ssh apk add sqlite rsync docker
 
+#For some reason, gravitysynctest wants to restart now so we will have to wait for it
+wait=30
+echo "Waiting for gravitysynctest to restart"
+until [ docker container ls --format "table {{.Names}}\t{{.Status}}" | grep gravitysynctest | grep Up ]
+do
+  sleep 1
+  wait=$[$wait-1]
+  if [ $wait -eq 0 ]
+  then
+    echo "Timed out while awaiting gravitysynctest restart"
+    exit 1
+  fi
+done
+
 echo "Add the SSH container's host key to the GravitySync container's local store"
 docker exec gravitysynctest ssh -o BatchMode=yes -o StrictHostKeyChecking=no -i /root/.ssh/id_rsa -p 2222 gravitysync@172.31.255.2 exit 0
 

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -30,16 +30,17 @@ docker run -v "$TESTDIR/:$TESTDIR/.ssh:rw" --rm alpine:latest apk --update add o
 docker-compose -f ${WORKDIR}/docker-testenvironment-compose.yml up -d
 docker container ls -a --format "table {{.ID}}\t{{.Image}}\t{{.Names}}"
 
-# Prepare the SSH container to accommodate for GravitySync's requirements
+echo "Prepare the SSH container to accommodate for GravitySync's requirements"
 docker exec ssh sh -c 'chmod +w /etc/sudoers && sudo sed -i "s/^gravitysync.*$/gravitysync ALL=(ALL) NOPASSWD: ALL/" /etc/sudoers'
 docker exec ssh apk add sqlite rsync docker
 
-# Add the SSH container's host key to the GravitySync container's local store
+echo "Add the SSH container's host key to the GravitySync container's local store"
 docker exec gravitysynctest ssh -o BatchMode=yes -o StrictHostKeyChecking=no -i /root/.ssh/id_rsa -p 2222 gravitysync@172.31.255.2 exit 0
 
+echo "cat /test"
 docker exec gravitysynctest cat /test
 
-# Insert a new custom DNS record in the "primary" pihole and test it
+echo 'Insert a new custom DNS record in the "primary" pihole and test it'
 docker exec pihole1 sh -c 'echo "127.0.0.1 dnstest.local" > /etc/pihole/custom.list'
 docker exec pihole1 /usr/local/bin/pihole restartdns
 echo 'Waiting 10 seconds after PiHole DNS restart'

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -51,6 +51,8 @@ do
   fi
 done
 
+sleep 5
+
 echo "Add the SSH container's host key to the GravitySync container's local store"
 docker exec gravitysynctest ssh -o BatchMode=yes -o StrictHostKeyChecking=no -i /root/.ssh/id_rsa -p 2222 gravitysync@172.31.255.2 exit 0
 

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -36,6 +36,8 @@ docker exec ssh apk add sqlite rsync docker
 # Add the SSH container's host key to the GravitySync container's local store
 docker exec gravitysynctest ssh -o BatchMode=yes -o StrictHostKeyChecking=no -i /root/.ssh/id_rsa -p 2222 gravitysync@172.31.255.2 exit 0
 
+docker exec gravitysynctest cat /test
+
 # Insert a new custom DNS record in the "primary" pihole and test it
 docker exec pihole1 sh -c 'echo "127.0.0.1 dnstest.local" > /etc/pihole/custom.list'
 docker exec pihole1 /usr/local/bin/pihole restartdns

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -34,24 +34,30 @@ echo "Prepare the SSH container to accommodate for GravitySync's requirements"
 docker exec ssh sh -c 'chmod +w /etc/sudoers && sudo sed -i "s/^gravitysync.*$/gravitysync ALL=(ALL) NOPASSWD: ALL/" /etc/sudoers'
 docker exec ssh apk add sqlite rsync docker
 
-docker stop gravitysynctest
-docker start gravitysynctest
+#docker stop gravitysynctest
+#docker start gravitysynctest
 
 #For some reason, gravitysynctest wants to restart now so we will have to wait for it
-wait=30
-echo "Waiting for gravitysynctest to restart"
-until docker container ls --format "table {{.Names}}\t{{.Status}}" | grep gravitysynctest | grep Up
-do
-  sleep 1
-  wait="$(($wait - 1))"
-  if [ "${wait}" -eq 0 ]
-  then
-    echo "Timed out while awaiting gravitysynctest restart"
-    exit 1
-  fi
-done
+#wait=30
+#echo "Waiting for gravitysynctest to restart"
+#until docker container ls --format "table {{.Names}}\t{{.Status}}" | grep gravitysynctest | grep Up
+#do
+#  sleep 1
+#  wait="$(($wait - 1))"
+#  if [ "${wait}" -eq 0 ]
+#  then
+#    echo "Timed out while awaiting gravitysynctest restart"
+#    exit 1
+#  fi
+#done
 
-sleep 5
+#sleep 5
+
+echo ----------------------------------------------------------------------------------------------------------------------------------------------------------------
+echo
+echo
+
+docker logs gravitysynctest
 
 echo "Add the SSH container's host key to the GravitySync container's local store"
 docker exec gravitysynctest ssh -o BatchMode=yes -o StrictHostKeyChecking=no -i /root/.ssh/id_rsa -p 2222 gravitysync@172.31.255.2 exit 0

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -40,7 +40,7 @@ echo "Waiting for gravitysynctest to restart"
 until docker container ls --format "table {{.Names}}\t{{.Status}}" | grep gravitysynctest | grep Up
 do
   sleep 1
-  wait=$($wait-1)
+  wait=$wait-1
   if [ "${wait}" -eq 0 ]
   then
     echo "Timed out while awaiting gravitysynctest restart"

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -27,9 +27,8 @@ mkdir -p ${TESTDIR}/.ssh/
 docker run -v "$TESTDIR/:$TESTDIR/.ssh:rw" --rm alpine:latest apk --update add openssh-client && ssh-keygen -q -t rsa -f ${TESTDIR}/.ssh/id_rsa -N ''
 
 # Bring the testing environment online
-echo "Executing Docker Compose Up"
 docker-compose -f ${WORKDIR}/docker-testenvironment-compose.yml up -d
-echo "Docker Compose IS NOW Up"
+docker container ls -a --format "table {{.ID}}\t{{.Image}}\t{{.Names}}"
 
 # Prepare the SSH container to accommodate for GravitySync's requirements
 docker exec ssh sh -c 'chmod +w /etc/sudoers && sudo sed -i "s/^gravitysync.*$/gravitysync ALL=(ALL) NOPASSWD: ALL/" /etc/sudoers'

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -30,42 +30,14 @@ docker run -v "$TESTDIR/:$TESTDIR/.ssh:rw" --rm alpine:latest apk --update add o
 docker-compose -f ${WORKDIR}/docker-testenvironment-compose.yml up -d
 docker container ls -a --format "table {{.ID}}\t{{.Image}}\t{{.Names}}"
 
-echo "Prepare the SSH container to accommodate for GravitySync's requirements"
+#Prepare the SSH container to accommodate for GravitySync's requirements
 docker exec ssh sh -c 'chmod +w /etc/sudoers && sudo sed -i "s/^gravitysync.*$/gravitysync ALL=(ALL) NOPASSWD: ALL/" /etc/sudoers'
 docker exec ssh apk add sqlite rsync docker
 
-#docker stop gravitysynctest
-#docker start gravitysynctest
-
-#For some reason, gravitysynctest wants to restart now so we will have to wait for it
-#wait=30
-#echo "Waiting for gravitysynctest to restart"
-#until docker container ls --format "table {{.Names}}\t{{.Status}}" | grep gravitysynctest | grep Up
-#do
-#  sleep 1
-#  wait="$(($wait - 1))"
-#  if [ "${wait}" -eq 0 ]
-#  then
-#    echo "Timed out while awaiting gravitysynctest restart"
-#    exit 1
-#  fi
-#done
-
-#sleep 5
-
-echo ----------------------------------------------------------------------------------------------------------------------------------------------------------------
-echo
-echo
-
-docker logs gravitysynctest
-
-echo "Add the SSH container's host key to the GravitySync container's local store"
+#Add the SSH container's host key to the GravitySync container's local store
 docker exec gravitysynctest ssh -o BatchMode=yes -o StrictHostKeyChecking=no -i /root/.ssh/id_rsa -p 2222 gravitysync@172.31.255.2 exit 0
 
-echo "cat /test"
-docker exec gravitysynctest cat /test
-
-echo 'Insert a new custom DNS record in the "primary" pihole and test it'
+#Insert a new custom DNS record in the "primary" pihole and test it
 docker exec pihole1 sh -c 'echo "127.0.0.1 dnstest.local" > /etc/pihole/custom.list'
 docker exec pihole1 /usr/local/bin/pihole restartdns
 echo 'Waiting 10 seconds after PiHole DNS restart'

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -30,14 +30,14 @@ docker run -v "$TESTDIR/:$TESTDIR/.ssh:rw" --rm alpine:latest apk --update add o
 docker-compose -f ${WORKDIR}/docker-testenvironment-compose.yml up -d
 docker container ls -a --format "table {{.ID}}\t{{.Image}}\t{{.Names}}"
 
-#Prepare the SSH container to accommodate for GravitySync's requirements
+# Prepare the SSH container to accommodate for GravitySync's requirements
 docker exec ssh sh -c 'chmod +w /etc/sudoers && sudo sed -i "s/^gravitysync.*$/gravitysync ALL=(ALL) NOPASSWD: ALL/" /etc/sudoers'
 docker exec ssh apk add sqlite rsync docker
 
-#Add the SSH container's host key to the GravitySync container's local store
+# Add the SSH container's host key to the GravitySync container's local store
 docker exec gravitysynctest ssh -o BatchMode=yes -o StrictHostKeyChecking=no -i /root/.ssh/id_rsa -p 2222 gravitysync@172.31.255.2 exit 0
 
-#Insert a new custom DNS record in the "primary" pihole and test it
+# Insert a new custom DNS record in the "primary" pihole and test it
 docker exec pihole1 sh -c 'echo "127.0.0.1 dnstest.local" > /etc/pihole/custom.list'
 docker exec pihole1 /usr/local/bin/pihole restartdns
 echo 'Waiting 10 seconds after PiHole DNS restart'

--- a/dev_scripts/test
+++ b/dev_scripts/test
@@ -34,6 +34,9 @@ echo "Prepare the SSH container to accommodate for GravitySync's requirements"
 docker exec ssh sh -c 'chmod +w /etc/sudoers && sudo sed -i "s/^gravitysync.*$/gravitysync ALL=(ALL) NOPASSWD: ALL/" /etc/sudoers'
 docker exec ssh apk add sqlite rsync docker
 
+docker stop gravitysynctest
+docker start gravitysynctest
+
 #For some reason, gravitysynctest wants to restart now so we will have to wait for it
 wait=30
 echo "Waiting for gravitysynctest to restart"


### PR DESCRIPTION
Adjusted SSH_PKIF (SSH key path) handling to be consistent with gravity-sync usage, which uses it relative to ~. Note, custom keys residing in a folder, ex: "~/.ssh/CUSTOM_KEY", need to specify the full path relative to ~ in SSH_PKIF, ex: ".ssh/CUSTOM_KEY" would be correct.

Upstream gravity-sync scripts use SSH_PKIF consistently like below.

From includes/gs-ssh.sh release 3.7.0 line 39: 
> if [ -f $HOME/${SSH_PKIF} ]

Not sure if your approach would be to be more explicit and define a new env var to handle the presumable ".ssh/" part. Another option would be suggesting upstream to gravity-sync that usage is relative to ~/.ssh/, aka $HOME/.ssh/${SSH_PKIF}. I would guess best practice would keep keys relative to ~/.ssh, but not sure how to think about it when it's mapped in as a volume.